### PR TITLE
Fix: CommentsRule should not treat presence of `import` keyword alone…

### DIFF
--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/comments/CommentsRule.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter2/comments/CommentsRule.kt
@@ -11,12 +11,14 @@ import com.pinterest.ktlint.core.ast.ElementType.EOL_COMMENT
 import com.pinterest.ktlint.core.ast.ElementType.FILE
 import com.pinterest.ktlint.core.ast.ElementType.WHITE_SPACE
 import com.pinterest.ktlint.core.ast.prevSibling
+import org.cqfn.diktat.ruleset.utils.getFilePath
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.TokenType
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtPsiFactory
 import org.jetbrains.kotlin.resolve.ImportPath
+import org.slf4j.LoggerFactory
 
 /**
  * This rule performs checks if there is any commented code.
@@ -68,10 +70,10 @@ class CommentsRule(configRules: List<RulesConfig>) : DiktatRule(
             .map { (offset, text) -> offset to text.trim() }
             .mapNotNull { (offset, text) ->
                 when {
-                    text.contains(importKeyword) ->
-                        offset to ktPsiFactory.createImportDirective(ImportPath.fromString(text.substringAfter("$importKeyword "))).node
-                    text.contains(packageKeyword) ->
-                        offset to ktPsiFactory.createPackageDirective(FqName(text.substringAfter("$packageKeyword "))).node
+                    text.mayBeImport() ->
+                        offset to ktPsiFactory.createImportDirective(ImportPath.fromString(text.substringAfter(importKeywordWithSpace, ""))).node
+                    text.trimStart().startsWith(packageKeywordWithSpace) ->
+                        offset to ktPsiFactory.createPackageDirective(FqName(text.substringAfter(packageKeywordWithSpace, ""))).node
                     else -> if (isContainingRequiredPartOfCode(text)) {
                         offset to ktPsiFactory.createBlockCodeFragment(text, null).node
                     } else {
@@ -85,8 +87,23 @@ class CommentsRule(configRules: List<RulesConfig>) : DiktatRule(
                     .isEmpty()
             }
             .forEach { (offset, parsedNode) ->
-                COMMENTED_OUT_CODE.warn(configRules, emitWarn, isFixMode, parsedNode.text.substringBefore("\n").trim(), offset,
-                    errorNodesWithText.find { it.second.trim().contains(parsedNode.text, false) || parsedNode.text.contains(it.second.trim(), false) }?.first!!)
+                val invalidNode = errorNodesWithText.find {
+                    it.second.trim().contains(parsedNode.text, false) ||
+                            parsedNode.text.contains(it.second.trim(), false)
+                }?.first
+                if (invalidNode == null) {
+                    logger.warn("Text [${parsedNode.text}] is a piece of code, created from comment; " +
+                            "but no matching text in comments has been found in the file ${node.getFilePath()}")
+                } else {
+                    COMMENTED_OUT_CODE.warn(
+                        configRules,
+                        emitWarn,
+                        isFixMode,
+                        parsedNode.text.substringBefore("\n").trim(),
+                        offset,
+                        invalidNode
+                    )
+                }
             }
     }
 
@@ -139,11 +156,24 @@ class CommentsRule(configRules: List<RulesConfig>) : DiktatRule(
     private fun isContainingRequiredPartOfCode(text: String): Boolean =
             text.contains("val ", true) || text.contains("var ", true) || text.contains("=", true) || (text.contains("{", true) && text.substringAfter("{").contains("}", true))
 
+    /**
+     * Some weak checks to see if this string can be used as a part of import statement.
+     * Only string surrounded in backticks or a dot-qualified expression (i.e., containing words maybe separated by dots)
+     * are considered for this case.
+     */
+    private fun String.mayBeImport(): Boolean {
+        return trimStart().startsWith(importKeywordWithSpace) &&
+                substringAfter(importKeywordWithSpace, "").run {
+                    startsWith('`') && endsWith('`') || !contains(' ')
+                }
+    }
+
     @Suppress("MaxLineLength")
     companion object {
-        private val importKeyword = KtTokens.IMPORT_KEYWORD.value
-        private val packageKeyword = KtTokens.PACKAGE_KEYWORD.value
-        private val importOrPackage = """($importKeyword|$packageKeyword) """.toRegex()
+        private val logger = LoggerFactory.getLogger(CommentsRule::class.java)
+        private val importKeywordWithSpace = "${KtTokens.IMPORT_KEYWORD.value} "
+        private val packageKeywordWithSpace = "${KtTokens.PACKAGE_KEYWORD.value} "
+        private val importOrPackage = """($importKeywordWithSpace|$packageKeywordWithSpace)""".toRegex()
         private val classRegex =
                 """^\s*(public|private|protected)*\s*(internal)*\s*(open|data|sealed)*\s*(internal)*\s*(class|object)\s+(\w+)(\(.*\))*(\s*:\s*\w+(\(.*\))*)?\s*\{*$""".toRegex()
         private val importOrPackageRegex = """^(import|package)?\s+([a-zA-Z.])+;*$""".toRegex()

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/comments/CommentedCodeTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter2/comments/CommentedCodeTest.kt
@@ -453,4 +453,21 @@ class CommentedCodeTest : LintTestBase(::CommentsRule) {
             """.trimMargin()
         )
     }
+
+    @Test
+    @Tag(WarningNames.COMMENTED_OUT_CODE)
+    fun `should not trigger on 'imports'`() {
+        lintMethod(
+            """
+            /* Checks if specified imports can be found in classpath. */
+            class Example
+            
+            /* Checks if specified import can be found in classpath. */
+            class Example2
+            
+            /* import this and you died. */
+            class Example3
+            """.trimMargin()
+        )
+    }
 }


### PR DESCRIPTION
… as code

### What's done:
* Fix in logic
* Add tests

## Which rule and warnings did you add?

This pull request closes #1091