### PR TITLE
Fix: Don't check length of import statements

### DIFF
--- a/diktat-gradle-plugin/settings.gradle.kts
+++ b/diktat-gradle-plugin/settings.gradle.kts
@@ -1,0 +1,6 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}

--- a/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/LineLength.kt
+++ b/diktat-rules/src/main/kotlin/org/cqfn/diktat/ruleset/rules/chapter3/LineLength.kt
@@ -66,15 +66,17 @@ class LineLength(configRules: List<RulesConfig>) : DiktatRule(
     "line-length",
     configRules,
     listOf(LONG_LINE)) {
+    private val configuration by lazy {
+        LineLengthConfiguration(
+            configRules.getRuleConfig(LONG_LINE)?.configuration ?: emptyMap()
+        )
+    }
     private lateinit var positionByOffset: (Int) -> Pair<Int, Int>
 
     override fun logic(node: ASTNode) {
-        val configuration = LineLengthConfiguration(
-            configRules.getRuleConfig(LONG_LINE)?.configuration ?: emptyMap())
-
         if (node.elementType == FILE) {
             node.getChildren(null).forEach {
-                if (it.elementType != PACKAGE_DIRECTIVE || it.elementType != IMPORT_LIST) {
+                if (it.elementType != PACKAGE_DIRECTIVE && it.elementType != IMPORT_LIST) {
                     checkLength(it, configuration)
                 }
             }

--- a/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/LineLengthWarnTest.kt
+++ b/diktat-rules/src/test/kotlin/org/cqfn/diktat/ruleset/chapter3/LineLengthWarnTest.kt
@@ -53,7 +53,8 @@ class LineLengthWarnTest : LintTestBase(::LineLength) {
                     |   fun foo() {
                     |   }
                     |}
-                """.trimMargin()
+                """.trimMargin(),
+            rulesConfigList = shortLineLength
         )
     }
 


### PR DESCRIPTION
### What's done:
* Fix bug in code
* Update test

## Which rule and warnings did you add?

This pull request closes #1077 
We actually had logic, which doesn't check length of package directives and import statements. However, due to a small bug, it was not working from the very beginning...